### PR TITLE
Fix move, use ndmoving for ewm

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -178,12 +178,18 @@ class NumbaNDReduce(object):
 MOVE_WINDOW_ERR_MSG = "invalid window (not between 1 and %d, inclusive): %r"
 
 
+def rolling_check(arr, window):
+    if (window < 1) or (window > arr.shape[-1]):
+        raise ValueError(MOVE_WINDOW_ERR_MSG % (arr.shape[-1], window))
+
+
 DEFAULT_MOVING_SIGNATURE = ((numba.float64[:], numba.int64, numba.float64[:]),)
 
 
 class NumbaNDMoving(object):
-    def __init__(self, func, signature=DEFAULT_MOVING_SIGNATURE):
+    def __init__(self, func, signature=DEFAULT_MOVING_SIGNATURE, window_check=rolling_check):
         self.func = func
+        self.window_check = window_check
 
         ndims = tuple(ndim(arg) for arg in signature[0])
         for sig in signature:
@@ -204,15 +210,12 @@ class NumbaNDMoving(object):
         gufunc_sig = gufunc_string_signature(self.signature[0])
         vectorize = numba.guvectorize(
             self.signature, gufunc_sig, nopython=True)
-        return vectorize(self.transformed_func)
+        return vectorize(self.func)
 
     def __call__(self, arr, window, axis=-1):
         axis = _validate_axis(axis, arr.ndim)
-        window = np.asarray(window)
-        # TODO: test this validation
-        if (window < 1).any() or (window > arr.shape[axis]).any():
-            raise ValueError(MOVE_WINDOW_ERR_MSG % (arr.shape[axis], window))
         arr = np.moveaxis(arr, axis, -1)
+        self.window_check(arr, window)
         result = self.gufunc(arr, window)
         return np.moveaxis(result, -1, axis)
 
@@ -243,7 +246,7 @@ class NumbaGroupNDReduce(object):
         return '<numbagg.decorators.NumbaGroupNDReduce %s>' % self.__name__
 
     def _create_gufunc(self, core_ndim):
-        # ompiling gufuncs has some significant overhead (~130ms per function
+        # compiling gufuncs has some significant overhead (~130ms per function
         # and number of dimensions to aggregate), so do this in a lazy fashion
         numba_sig = []
         slices = (slice(None),) * core_ndim
@@ -290,5 +293,4 @@ class NumbaGroupNDReduce(object):
         broadcast_shape = values.shape[:broadcast_ndim]
         result = np.zeros(broadcast_shape + (num_labels,), values.dtype)
         gufunc(values, labels, result)
-        # assert False
         return result

--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -187,11 +187,11 @@ DEFAULT_MOVING_SIGNATURE = ((numba.float64[:], numba.int64, numba.float64[:]),)
 
 
 class NumbaNDMoving(object):
-    def __init__(self, func, signature=DEFAULT_MOVING_SIGNATURE, window_check=rolling_check):
+    def __init__(self, func, signature=DEFAULT_MOVING_SIGNATURE,
+                 window_check=rolling_check):
         self.func = func
         self.window_check = window_check
 
-        ndims = tuple(ndim(arg) for arg in signature[0])
         for sig in signature:
             if not isinstance(sig, tuple):
                 raise TypeError('signatures for ndmoving must be tuples: {}'

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numba import float64, guvectorize, int64
+from numba import float64, int64
 
 from .decorators import ndmoving
 

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -4,7 +4,7 @@ from numba import float64, int64
 from .decorators import ndmoving
 
 
-def ewm_window_check(arr, window):
+def ewm_window_validator(arr, window):
     if (window < 0):
         raise ValueError("Com must be positive; currently {}".format(window))
 
@@ -12,7 +12,7 @@ def ewm_window_check(arr, window):
 @ndmoving([
     (float64[:], float64, float64[:]),
 ],
-    window_check=ewm_window_check
+    window_validator=ewm_window_validator
 )
 def ewm_nanmean(a, com, out):
 

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -4,12 +4,9 @@ from numba import float64, guvectorize, int64
 from .decorators import ndmoving
 
 
-@guvectorize(
-    [(float64[:], float64, float64[:])],
-    signature='(n),()->(n)',
-    nopython=True,
-    target='parallel',
-)
+@ndmoving([
+    (float64[:], float64, float64[:]),
+])
 def ewm_nanmean(a, com, out):
 
     N = len(a)
@@ -49,6 +46,7 @@ def ewm_nanmean(a, com, out):
     (float64[:], int64, float64[:]),
 ])
 def move_nanmean(a, window, out):
+
     asum = 0.0
     count = 0
     for i in range(window - 1):

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -4,9 +4,16 @@ from numba import float64, guvectorize, int64
 from .decorators import ndmoving
 
 
+def ewm_window_check(arr, window):
+    if (window < 0):
+        raise ValueError("Com must be positive; currently {}".format(window))
+
+
 @ndmoving([
     (float64[:], float64, float64[:]),
-])
+],
+    window_check=ewm_window_check
+)
 def ewm_nanmean(a, com, out):
 
     N = len(a)

--- a/numbagg/test/test_funcs.py
+++ b/numbagg/test/test_funcs.py
@@ -12,7 +12,6 @@ def arrays(dtypes=numbagg.dtypes, nans=True):
     "Iterator that yields arrays to use for unit testing."
     ss = {}
     ss[0] = {'size':  0, 'shapes': [(0,), (0, 0), (2, 0), (2, 0, 1)]}
-    # ss[0] = {'size':  0, 'shapes': [(0,), (0, 0)]}
     ss[1] = {'size':  4, 'shapes': [(4,)]}
     ss[2] = {'size':  6, 'shapes': [(1, 6), (2, 3)]}
     ss[3] = {'size':  6, 'shapes': [(1, 2, 3)]}
@@ -104,7 +103,7 @@ def test_numerical_results_identical(func, func0, decimal, nans=True):
                     # correctly
                     desired[~all_missing] = actual[~all_missing]
 
-                tup = (func.__name__, 'a'+str(i), str(arr.dtype),
+                tup = (func.__name__, 'a' + str(i), str(arr.dtype),
                        str(arr.shape), str(axis), arr)
                 err_msg = msg % tup
                 if (decimal < np.inf) and (np.isfinite(arr).sum() > 0):

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -3,21 +3,41 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 import pytest
 
-from numbagg.moving import ewm_nanmean
+from numbagg.moving import ewm_nanmean, move_nanmean
 
 
-def test_ewma():
+@pytest.fixture
+def array():
+    return np.random.rand(2000).reshape(200, -1)
 
-    array = np.random.rand(2000)
+
+def test_ewma(array):
+
+    array = array[0]
     expected = pd.Series(array).ewm(com=3).mean()
     result = ewm_nanmean(array, 3)
 
     assert_almost_equal(expected, result)
 
 
-def test_ewma_nd():
+def test_ewma_2d(array):
 
-    array = np.random.rand(4, 2000)
-    result = np.empty(array.shape)
-    ewm_nanmean(array, 3)
+    expected = pd.DataFrame(array).T.ewm(com=3).mean().T
+    result = ewm_nanmean(array, 3)
 
+    assert_almost_equal(expected, result)
+
+
+def test_movemean(array):
+
+    array = array[0]
+    expected = pd.Series(array).rolling(window=10).mean()
+    result = move_nanmean(array, 10)
+
+    assert_almost_equal(expected, result)
+
+
+def test_movemean_window(array):
+
+    with pytest.raises(ValueError):
+        move_nanmean(array, window=0.5)

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -11,11 +11,12 @@ def array():
     return np.random.rand(2000).reshape(200, -1)
 
 
-def test_ewma(array):
+@pytest.mark.parametrize('com', [0.5, 3])
+def test_ewma(array, com):
 
     array = array[0]
-    expected = pd.Series(array).ewm(com=3).mean()
-    result = ewm_nanmean(array, 3)
+    expected = pd.Series(array).ewm(com=com).mean()
+    result = ewm_nanmean(array, com)
 
     assert_almost_equal(expected, result)
 


### PR DESCRIPTION
`move_nanmean` didn't have tests and didn't work

I added a complication to the check for the window variable so we could use the same machinery. V open to a nicer way of accomplishing that...