### PR TITLE
Cleanup in preparation for public release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,8 @@ probably not yet ready for production.
 Benchmarks
 ----------
 
-Initial benchmarks are quite encouraging. In many cases, Numbagg/Numba has
-competitive performance with Bottleneck/Cython::
+Initial benchmarks are quite encouraging. Numbagg/Numba has comparable
+(slightly better) performance than Bottleneck's hand-written C::
 
     import numbagg
     import numpy as np
@@ -69,31 +69,25 @@ competitive performance with Bottleneck/Cython::
     x = np.random.RandomState(42).randn(1000, 1000)
     x[x < -1] = np.NaN
 
-    # timings with numba=0.15.1-20-gd877602 and bottleneck=0.8.0
+    # timings with numba=0.41.0 and bottleneck=1.2.1
 
-    In [4]: %timeit numbagg.nanmean(x)
-    100 loops, best of 3: 2.39 ms per loop
+    In [2]: %timeit numbagg.nanmean(x)
+    1.8 ms ± 92.3 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
 
-    In [5]: %timeit numbagg.nanmean(x, axis=0)
-    100 loops, best of 3: 9.54 ms per loop
+    In [3]: %timeit numbagg.nanmean(x, axis=0)
+    3.63 ms ± 136 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 
-    In [6]: %timeit numbagg.nanmean(x, axis=1)
-    100 loops, best of 3: 2.77 ms per loop
+    In [4]: %timeit numbagg.nanmean(x, axis=1)
+    1.81 ms ± 41 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
 
-    In [7]: %timeit bottleneck.nanmean(x)
-    100 loops, best of 3: 2.27 ms per loop
+    In [5]: %timeit bottleneck.nanmean(x)
+    2.22 ms ± 119 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 
-    In [8]: %timeit bottleneck.nanmean(x, axis=0)
-    100 loops, best of 3: 9.03 ms per loop
+    In [6]: %timeit bottleneck.nanmean(x, axis=0)
+    4.45 ms ± 107 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 
-    In [9]: %timeit bottleneck.nanmean(x, axis=1)
-    100 loops, best of 3: 2.3 ms per loop
-
-To see these performance numbers, you'll need to install the dev version of
-Numba, as Numba's handling of the ``.flat`` iterator was sped up considerably
-in `a recent PR`__.
-
-__ https://github.com/numba/numba/pull/817
+    In [7]: %timeit bottleneck.nanmean(x, axis=1)
+    2.19 ms ± 13.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 
 Philosophy
 ----------

--- a/numbagg/__init__.py
+++ b/numbagg/__init__.py
@@ -12,7 +12,4 @@ from .funcs import (
     nansum,
 )
 from .grouped import group_nanmean
-from .moving import move_nanmean
-from .decorators import ndreduce, ndmoving
-
-dtypes = ["float32", "float64"]
+from .moving import move_exp_nanmean, move_nanmean

--- a/numbagg/moving.py
+++ b/numbagg/moving.py
@@ -1,16 +1,19 @@
 import numpy as np
-from numba import float64, int64
+from numba import float32, float64, int64, int32
 
 from .decorators import ndmoving
 
 
-def ewm_window_validator(arr, window):
+def exp_window_validator(arr, window):
     if window < 0:
         raise ValueError("Com must be positive; currently {}".format(window))
 
 
-@ndmoving([(float64[:], float64, float64[:])], window_validator=ewm_window_validator)
-def rolling_exp_nanmean(a, alpha, out):
+@ndmoving(
+    [(float64[:], float64, float64[:]), (float32[:], float32, float32[:])],
+    window_validator=exp_window_validator,
+)
+def move_exp_nanmean(a, alpha, out):
 
     N = len(a)
     if N == 0:
@@ -47,7 +50,14 @@ def rolling_exp_nanmean(a, alpha, out):
         out[i] = weighted_avg
 
 
-@ndmoving([(float64[:], int64, float64[:])])
+@ndmoving(
+    [
+        (float64[:], int64, float64[:]),
+        (float32[:], int64, float32[:]),
+        (float64[:], int32, float64[:]),
+        (float32[:], int32, float32[:]),
+    ]
+)
 def move_nanmean(a, window, out):
 
     asum = 0.0

--- a/numbagg/test/test_funcs.py
+++ b/numbagg/test/test_funcs.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_equal
 
 
-def arrays(dtypes=numbagg.dtypes, nans=True):
+def arrays(dtypes=[np.float32, np.float64], nans=True):
     "Iterator that yields arrays to use for unit testing."
     ss = {}
     ss[0] = {"size": 0, "shapes": [(0,), (0, 0), (2, 0), (2, 0, 1)]}

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_almost_equal
 
-from numbagg.moving import move_nanmean, rolling_exp_nanmean
+from numbagg import move_nanmean, move_exp_nanmean
 
 
 @pytest.fixture
@@ -13,19 +13,19 @@ def array():
 
 
 @pytest.mark.parametrize("alpha", [0.5, 0.1])
-def test_rolling_exp_nanmean(array, alpha):
+def test_move_exp_nanmean(array, alpha):
 
     array = array[0]
     expected = pd.Series(array).ewm(alpha=alpha).mean()
-    result = rolling_exp_nanmean(array, alpha)
+    result = move_exp_nanmean(array, alpha)
 
     assert_almost_equal(expected, result)
 
 
-def test_rolling_exp_nanmean_2d(array):
+def test_move_exp_nanmean_2d(array):
 
     expected = pd.DataFrame(array).T.ewm(alpha=0.1).mean().T
-    result = rolling_exp_nanmean(array, 0.1)
+    result = move_exp_nanmean(array, 0.1)
 
     assert_almost_equal(expected, result)
 


### PR DESCRIPTION
- Remove decorators from `__init__.py`.
- Rename `rolling_exp_nanmean` -> `move_exp_nanmean` for consistency.
- Update readme benchmarks for latest numba
