### PR TITLE
Return original array when axis is empty tuple

### DIFF
--- a/numbagg/decorators.py
+++ b/numbagg/decorators.py
@@ -247,6 +247,11 @@ class NumbaNDMovingExp(NumbaNDMoving):
     def __call__(self, arr, alpha, axis=-1):
         if alpha < 0:
             raise ValueError("alpha must be positive: {}".format(alpha))
+        # If an empty tuple is passed, there's no reduction to do, so we return the
+        # original array.
+        # Ref https://github.com/pydata/xarray/pull/5178/files#r616168398
+        if axis == ():
+            return arr
         axis = _validate_axis(axis, arr.ndim)
         arr = np.moveaxis(arr, axis, -1)
         result = self.gufunc(arr, alpha)

--- a/numbagg/test/test_moving.py
+++ b/numbagg/test/test_moving.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 import pandas as pd
 import pytest
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_equal
 
 from numbagg import move_mean, move_exp_nanmean
 from .util import arrays, array_order
@@ -62,6 +62,11 @@ def test_move_mean_window(rand_array):
         move_mean(rand_array, window=-1)
     with pytest.raises(ValueError):
         move_mean(rand_array, window=1, min_count=-1)
+
+
+def test_tuple_axis_arg(rand_array):
+    result = move_exp_nanmean(rand_array, axis=())
+    assert_equal(result, rand_array)
 
 
 def functions():


### PR DESCRIPTION
Based on the discussion with @mathause https://github.com/pydata/xarray/pull/5178/files#r616168398.

I'm not sure whether this should go here, though. To the extent that xarray is the only library passing empty tuples as axis args, it should probably go back there. Happy to take direction!